### PR TITLE
Add countdown challenge mini game experience

### DIFF
--- a/countdown-game.html
+++ b/countdown-game.html
@@ -1,0 +1,552 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>倒计时挑战小游戏 | TimeMaster 专注模式</title>
+    <meta name="description" content="倒计时挑战小游戏，选择 5、10 或 15 分钟的专注挑战，完成任务获得积分，提升时间管理能力。">
+    <meta name="keywords" content="倒计时挑战,倒计时小游戏,专注训练,时间管理,TimeMaster 小游戏">
+    <meta name="author" content="TimeMaster">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://yourdomain.com/countdown-game.html">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://yourdomain.com/countdown-game.html">
+    <meta property="og:title" content="倒计时挑战小游戏 | TimeMaster">
+    <meta property="og:description" content="进入倒计时挑战小游戏，选择 5 / 10 / 15 分钟的专注挑战，完成任务累积积分。">
+    <meta property="og:image" content="https://yourdomain.com/game-og-image.jpg">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://yourdomain.com/countdown-game.html">
+    <meta property="twitter:title" content="倒计时挑战小游戏 | TimeMaster">
+    <meta property="twitter:description" content="倒计时挑战小游戏，选择不同时长的专注挑战，完成任务赢取徽章。">
+    <meta property="twitter:image" content="https://yourdomain.com/game-og-image.jpg">
+
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="manifest" href="/manifest.json">
+
+    <link rel="preload" href="styles.css" as="style">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" as="style">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+
+    <style>
+        body {
+            background: linear-gradient(180deg, rgba(102,126,234,0.15) 0%, rgba(118,75,162,0.1) 100%);
+        }
+
+        .game-shell {
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 40px 20px 80px;
+        }
+
+        .page-header {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+
+        .page-header h1 {
+            font-size: 2.8rem;
+            font-weight: 700;
+            color: #4b5cc4;
+        }
+
+        .page-header p {
+            margin-top: 12px;
+            color: #555;
+            font-size: 1.1rem;
+        }
+
+        .mode-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 20px;
+            margin-bottom: 40px;
+        }
+
+        .mode-card {
+            background: white;
+            border-radius: 16px;
+            padding: 24px;
+            box-shadow: 0 20px 40px rgba(102, 126, 234, 0.2);
+            border: 2px solid transparent;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            position: relative;
+        }
+
+        .mode-card.active {
+            border-color: #667eea;
+            box-shadow: 0 24px 50px rgba(102, 126, 234, 0.35);
+        }
+
+        .mode-card h3 {
+            font-size: 1.6rem;
+            margin-bottom: 6px;
+            color: #333;
+        }
+
+        .mode-card span {
+            color: #777;
+            font-size: 0.95rem;
+        }
+
+        .mode-badge {
+            position: absolute;
+            top: -10px;
+            right: 16px;
+            background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+            color: #fff;
+            font-size: 0.75rem;
+            font-weight: 600;
+            padding: 6px 12px;
+            border-radius: 999px;
+            box-shadow: 0 10px 20px rgba(250, 208, 196, 0.4);
+        }
+
+        .timer-board {
+            background: rgba(255,255,255,0.92);
+            border-radius: 20px;
+            padding: 32px;
+            box-shadow: 0 30px 60px rgba(102, 126, 234, 0.25);
+            text-align: center;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .timer-board::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 20% 20%, rgba(102,126,234,0.15), transparent 60%),
+                        radial-gradient(circle at 80% 10%, rgba(118,75,162,0.12), transparent 55%);
+            z-index: 0;
+        }
+
+        .timer-display {
+            font-size: 4rem;
+            font-weight: 700;
+            letter-spacing: 2px;
+            color: #3f4aa1;
+            margin-bottom: 16px;
+            position: relative;
+            z-index: 1;
+        }
+
+        .timer-progress {
+            width: 100%;
+            height: 12px;
+            background: rgba(102,126,234,0.15);
+            border-radius: 6px;
+            overflow: hidden;
+            margin-bottom: 24px;
+            position: relative;
+            z-index: 1;
+        }
+
+        .timer-progress-fill {
+            height: 100%;
+            background: linear-gradient(90deg, #667eea, #764ba2);
+            transition: width 0.2s ease;
+        }
+
+        .action-bar {
+            display: flex;
+            gap: 16px;
+            justify-content: center;
+            flex-wrap: wrap;
+            position: relative;
+            z-index: 1;
+        }
+
+        .action-button {
+            padding: 12px 28px;
+            border-radius: 999px;
+            border: none;
+            cursor: pointer;
+            font-weight: 600;
+            font-size: 1rem;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .action-button.primary {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #fff;
+            box-shadow: 0 14px 30px rgba(102, 126, 234, 0.3);
+        }
+
+        .action-button.secondary {
+            background: #f1f5f9;
+            color: #475569;
+        }
+
+        .action-button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        .action-button:not(:disabled):hover {
+            transform: translateY(-2px);
+        }
+
+        .challenge-box {
+            margin-top: 32px;
+            padding: 24px;
+            background: rgba(236, 240, 255, 0.7);
+            border-radius: 16px;
+            text-align: left;
+            position: relative;
+            z-index: 1;
+        }
+
+        .challenge-title {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-weight: 600;
+            color: #3f4aa1;
+            margin-bottom: 12px;
+        }
+
+        .challenge-content {
+            color: #475569;
+            line-height: 1.6;
+        }
+
+        .score-panel {
+            margin-top: 40px;
+            display: grid;
+            gap: 20px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        .score-card {
+            background: white;
+            border-radius: 16px;
+            padding: 20px;
+            box-shadow: 0 12px 30px rgba(148,163,184,0.2);
+        }
+
+        .score-card h4 {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 8px;
+        }
+
+        .achievement-list {
+            margin-top: 12px;
+            list-style: none;
+            padding: 0;
+        }
+
+        .achievement-list li {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px 0;
+            color: #475569;
+        }
+
+        .achievement-list li i {
+            color: #22c55e;
+        }
+
+        @media (max-width: 600px) {
+            .timer-display {
+                font-size: 3rem;
+            }
+
+            .mode-card {
+                padding: 20px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <nav class="navbar" role="navigation" aria-label="主导航">
+                <div class="nav-brand">
+                    <i class="fas fa-clock" aria-hidden="true"></i>
+                    <span>TimeMaster - 倒计时挑战</span>
+                </div>
+                <div class="nav-links">
+                    <a href="index.html" class="nav-link"><i class="fas fa-home"></i> 返回首页</a>
+                    <a href="game.html" class="nav-link"><i class="fas fa-gamepad"></i> 时间守护者</a>
+                </div>
+            </nav>
+        </header>
+
+        <main class="game-shell" role="main">
+            <div class="page-header">
+                <h1>倒计时挑战小游戏</h1>
+                <p>选择一个专注挑战时长，完成系统给出的小游戏任务，在倒计时内获得最高积分和徽章！</p>
+            </div>
+
+            <section class="mode-grid" aria-label="挑战模式">
+                <div class="mode-card active" data-minutes="5">
+                    <span class="mode-badge">热身</span>
+                    <h3>5 分钟闪电挑战</h3>
+                    <span>快速进入状态，适合短暂的专注训练。</span>
+                </div>
+                <div class="mode-card" data-minutes="10">
+                    <span class="mode-badge">经典</span>
+                    <h3>10 分钟稳固挑战</h3>
+                    <span>维持注意力，完成更多小目标。</span>
+                </div>
+                <div class="mode-card" data-minutes="15">
+                    <span class="mode-badge">耐力</span>
+                    <h3>15 分钟极限挑战</h3>
+                    <span>检验你的耐力，坚持到最后赢取徽章。</span>
+                </div>
+            </section>
+
+            <section class="timer-board" aria-live="polite">
+                <div class="timer-display" id="timerDisplay">05:00</div>
+                <div class="timer-progress">
+                    <div class="timer-progress-fill" id="timerProgress" style="width: 0%;"></div>
+                </div>
+                <div class="action-bar">
+                    <button class="action-button primary" id="startButton">开始挑战</button>
+                    <button class="action-button secondary" id="pauseButton" disabled>暂停</button>
+                    <button class="action-button secondary" id="resetButton" disabled>重置</button>
+                </div>
+
+                <div class="challenge-box" id="challengeBox">
+                    <div class="challenge-title"><i class="fas fa-bolt"></i> 当前任务</div>
+                    <div class="challenge-content" id="challengeContent">选择时长并点击开始，准备迎接第一条挑战提示！</div>
+                    <button class="action-button primary" id="challengeButton" style="margin-top: 16px; display: none;">完成任务 +10 分</button>
+                </div>
+            </section>
+
+            <section class="score-panel" aria-label="成绩概览">
+                <div class="score-card">
+                    <h4>当前得分</h4>
+                    <p id="scoreDisplay" style="font-size: 2rem; font-weight: 700; color: #f97316;">0</p>
+                    <p style="color:#64748b;">每成功完成一个任务获得 10 分，坚持到结束还有额外奖励。</p>
+                </div>
+                <div class="score-card">
+                    <h4>已解锁徽章</h4>
+                    <ul class="achievement-list" id="achievementList">
+                        <li><i class="fas fa-medal"></i> 等待你的第一枚徽章！</li>
+                    </ul>
+                </div>
+                <div class="score-card">
+                    <h4>游戏小贴士</h4>
+                    <p style="color:#475569; line-height:1.6;">在倒计时内完成尽可能多的任务。保持专注、及时点击“完成任务”按钮即可获取积分。倒计时结束时会根据得分赠送徽章。</p>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script>
+        const modeCards = document.querySelectorAll('.mode-card');
+        const timerDisplay = document.getElementById('timerDisplay');
+        const timerProgress = document.getElementById('timerProgress');
+        const startButton = document.getElementById('startButton');
+        const pauseButton = document.getElementById('pauseButton');
+        const resetButton = document.getElementById('resetButton');
+        const challengeBox = document.getElementById('challengeBox');
+        const challengeContent = document.getElementById('challengeContent');
+        const challengeButton = document.getElementById('challengeButton');
+        const scoreDisplay = document.getElementById('scoreDisplay');
+        const achievementList = document.getElementById('achievementList');
+
+        let selectedMinutes = 5;
+        let totalSeconds = selectedMinutes * 60;
+        let remainingSeconds = totalSeconds;
+        let timerInterval = null;
+        let challengeTimer = null;
+        let score = 0;
+        let challengesCompleted = 0;
+        let isRunning = false;
+        let hasStarted = false;
+
+        const challengePool = [
+            '深呼吸 3 次，让脑海保持清晰，然后点击“完成任务”。',
+            '环顾四周寻找 3 个蓝色的物品并记住它们，再点击“完成任务”。',
+            '写下今天想要完成的一个目标，完成后点击“完成任务”。',
+            '伸展手臂和肩膀 10 秒，舒展身体后回来点击按钮。',
+            '回想一件让你开心的小事，微笑 5 秒后点击“完成任务”。',
+            '快速整理桌面或文件，让环境更整洁，然后回来点击按钮。',
+            '闭眼聆听周围的声音 5 秒钟，感受当下，再完成任务。',
+            '喝一口水，让自己保持活力，之后点击“完成任务”。',
+            '在纸上画一个简单笑脸，完成后点击按钮。',
+            '想一个你感激的人或事，默念感谢，再点击“完成任务”。'
+        ];
+
+        const achievementRules = [
+            { threshold: 10, text: '初级挑战者：完成 1 个任务。' },
+            { threshold: 30, text: '专注达人：累计积分达到 30 分。' },
+            { threshold: 60, text: '时间掌控者：挑战期间完成 6 个任务。' },
+            { threshold: 100, text: '倒计时王者：积分突破 100 分。' }
+        ];
+
+        function formatTime(seconds) {
+            const m = Math.floor(seconds / 60).toString().padStart(2, '0');
+            const s = Math.floor(seconds % 60).toString().padStart(2, '0');
+            return `${m}:${s}`;
+        }
+
+        function updateDisplay() {
+            timerDisplay.textContent = formatTime(remainingSeconds);
+            const progress = ((totalSeconds - remainingSeconds) / totalSeconds) * 100;
+            timerProgress.style.width = `${progress}%`;
+        }
+
+        function resetGame() {
+            clearInterval(timerInterval);
+            clearTimeout(challengeTimer);
+            timerInterval = null;
+            challengeTimer = null;
+            isRunning = false;
+            hasStarted = false;
+            remainingSeconds = totalSeconds;
+            score = 0;
+            challengesCompleted = 0;
+            updateDisplay();
+            updateScore();
+            resetButtons();
+            resetAchievements();
+            challengeContent.textContent = '选择时长并点击开始，准备迎接第一条挑战提示！';
+            challengeButton.style.display = 'none';
+            challengeButton.disabled = false;
+        }
+
+        function resetAchievements() {
+            achievementList.innerHTML = '<li><i class="fas fa-medal"></i> 等待你的第一枚徽章！</li>';
+        }
+
+        function updateScore() {
+            scoreDisplay.textContent = score;
+            const achievements = achievementRules.filter(rule => score >= rule.threshold || challengesCompleted * 10 >= rule.threshold);
+            if (achievements.length) {
+                achievementList.innerHTML = achievements.map(rule => `<li><i class="fas fa-medal"></i> ${rule.text}</li>`).join('');
+            }
+        }
+
+        function startTimer() {
+            if (isRunning) return;
+            if (!hasStarted) {
+                score = 0;
+                challengesCompleted = 0;
+                updateScore();
+                challengeContent.textContent = '挑战开始！保持专注，随时准备接收新任务。';
+                scheduleNextChallenge(1000);
+            }
+            hasStarted = true;
+            isRunning = true;
+            startButton.disabled = true;
+            pauseButton.disabled = false;
+            resetButton.disabled = false;
+
+            timerInterval = setInterval(() => {
+                if (remainingSeconds <= 0) {
+                    clearInterval(timerInterval);
+                    clearTimeout(challengeTimer);
+                    timerInterval = null;
+                    challengeTimer = null;
+                    isRunning = false;
+                    challengeButton.style.display = 'none';
+                    finishGame();
+                    return;
+                }
+                remainingSeconds--;
+                updateDisplay();
+            }, 1000);
+        }
+
+        function pauseTimer() {
+            if (!isRunning) return;
+            clearInterval(timerInterval);
+            clearTimeout(challengeTimer);
+            timerInterval = null;
+            challengeTimer = null;
+            isRunning = false;
+            pauseButton.textContent = '继续';
+        }
+
+        function resumeTimer() {
+            if (isRunning || remainingSeconds <= 0) return;
+            pauseButton.textContent = '暂停';
+            if (challengeButton.style.display === 'none') {
+                scheduleNextChallenge(5000);
+            }
+            startTimer();
+        }
+
+        function scheduleNextChallenge(delay = 45000) {
+            clearTimeout(challengeTimer);
+            challengeTimer = setTimeout(() => {
+                const challenge = challengePool[Math.floor(Math.random() * challengePool.length)];
+                challengeContent.textContent = challenge;
+                challengeButton.style.display = 'inline-flex';
+                challengeButton.disabled = false;
+                challengeTimer = null;
+            }, delay);
+        }
+
+        function completeChallenge() {
+            score += 10;
+            challengesCompleted += 1;
+            challengeContent.textContent = '太棒了！准备迎接下一条任务。';
+            challengeButton.style.display = 'none';
+            updateScore();
+            scheduleNextChallenge();
+        }
+
+        function finishGame() {
+            startButton.disabled = false;
+            pauseButton.disabled = true;
+            resetButton.disabled = false;
+            pauseButton.textContent = '暂停';
+            const bonus = Math.round(totalSeconds / 60) * 5;
+            score += bonus;
+            updateScore();
+            challengeContent.textContent = `时间到！获得额外 ${bonus} 分坚持奖励，共计 ${score} 分。点击重置重新挑战。`;
+        }
+
+        function resetButtons() {
+            startButton.disabled = false;
+            pauseButton.disabled = true;
+            resetButton.disabled = true;
+            pauseButton.textContent = '暂停';
+        }
+
+        modeCards.forEach(card => {
+            card.addEventListener('click', () => {
+                modeCards.forEach(c => c.classList.remove('active'));
+                card.classList.add('active');
+                selectedMinutes = Number(card.dataset.minutes);
+                totalSeconds = selectedMinutes * 60;
+                remainingSeconds = totalSeconds;
+                updateDisplay();
+                resetGame();
+            });
+        });
+
+        startButton.addEventListener('click', startTimer);
+        pauseButton.addEventListener('click', () => {
+            if (isRunning) {
+                pauseTimer();
+            } else {
+                resumeTimer();
+            }
+        });
+        resetButton.addEventListener('click', resetGame);
+        challengeButton.addEventListener('click', () => {
+            challengeButton.disabled = true;
+            completeChallenge();
+        });
+
+        updateDisplay();
+    </script>
+</body>
+</html>

--- a/game.html
+++ b/game.html
@@ -242,6 +242,11 @@
             font-size: 1rem;
             cursor: pointer;
             margin: 0 10px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            text-decoration: none;
             transition: all 0.3s ease;
             box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
         }
@@ -257,6 +262,10 @@
             cursor: not-allowed;
             transform: none;
             box-shadow: none;
+        }
+
+        .game-header-actions {
+            margin-top: 20px;
         }
 
         .game-instructions {
@@ -359,6 +368,11 @@
         <header class="game-header">
             <h1 class="game-title">时间守护者 - 在线倒计时游戏</h1>
             <p class="game-subtitle">点击守护时间，挑战你的反应速度！不要让倒计时归零</p>
+            <div class="game-header-actions">
+                <a class="btn" href="countdown-game.html" aria-label="前往倒计时挑战小游戏">
+                    <i class="fas fa-hourglass-half" aria-hidden="true"></i> 尝试倒计时挑战
+                </a>
+            </div>
         </header>
 
         <div class="timer-display">

--- a/index.html
+++ b/index.html
@@ -100,6 +100,10 @@
                     <i class="fas fa-globe"></i>
                     世界时间工具
                 </a>
+                <a href="countdown-game.html" class="nav-link">
+                    <i class="fas fa-hourglass-half"></i>
+                    倒计时挑战
+                </a>
                 <a href="articles.html" class="nav-link">
                     <i class="fas fa-newspaper"></i>
                     文章专栏

--- a/sitemap.html
+++ b/sitemap.html
@@ -150,6 +150,15 @@
                             </div>
                         </li>
                         <li>
+                            <a href="countdown-game.html">
+                                <i class="fas fa-hourglass-half"></i>
+                                倒计时挑战小游戏
+                            </a>
+                            <div class="sitemap-description">
+                                选择 5/10/15 分钟挑战，完成任务积累积分，提升专注力的互动小游戏
+                            </div>
+                        </li>
+                        <li>
                             <a href="game.html">
                                 <i class="fas fa-gamepad"></i>
                                 时间守护者小游戏

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,7 +19,15 @@
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
-    
+
+    <!-- 倒计时挑战小游戏页面 -->
+    <url>
+        <loc>https://yourdomain.com/countdown-game.html</loc>
+        <lastmod>2024-01-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+
     <!-- 小游戏页面 -->
     <url>
         <loc>https://yourdomain.com/game.html</loc>


### PR DESCRIPTION
## Summary
- add a countdown challenge mini game page with selectable 5/10/15 minute modes, timed tasks, scoring, and achievements
- link the new game from the homepage navigation and the existing mini game page
- include the new page in the HTML and XML sitemaps for discovery

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da0ada690c8321af27210249933aac