### PR TITLE
style: redesign festival countdown cards

### DIFF
--- a/festival-countdown.html
+++ b/festival-countdown.html
@@ -183,116 +183,120 @@
 
         .festival-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            gap: 24px;
+            grid-template-columns: repeat(1, minmax(0, 1fr));
+            gap: 1px;
+            padding: 1px;
+            border-radius: 24px;
+            overflow: hidden;
+            background: rgba(99, 102, 241, 0.18);
         }
 
         .festival-card {
-            background: linear-gradient(160deg, rgba(255,255,255,0.98), rgba(241,245,249,0.92));
-            border-radius: 20px;
+            background: #ffffff;
             padding: 28px 24px;
-            box-shadow: 0 18px 40px rgba(148, 163, 184, 0.25);
             display: flex;
             flex-direction: column;
-            gap: 20px;
-            position: relative;
-            overflow: hidden;
+            align-items: center;
+            text-align: center;
+            gap: 18px;
+            transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
         }
 
-        .festival-card::after {
-            content: "";
-            position: absolute;
-            inset: 0;
-            background: radial-gradient(circle at top right, rgba(102, 126, 234, 0.12), transparent 55%);
-            pointer-events: none;
+        .festival-card:hover,
+        .festival-card:focus-within {
+            background: linear-gradient(145deg, rgba(237, 242, 255, 0.95), rgba(255, 255, 255, 0.98));
+            transform: translateY(-4px);
+            box-shadow: 0 18px 28px rgba(99, 102, 241, 0.15);
         }
 
         .festival-card-header {
             display: flex;
+            flex-direction: column;
             align-items: center;
-            gap: 16px;
-            position: relative;
-            z-index: 1;
+            gap: 12px;
         }
 
         .festival-icon {
-            width: 56px;
-            height: 56px;
-            border-radius: 16px;
-            background: rgba(102, 126, 234, 0.12);
+            width: 64px;
+            height: 64px;
+            border-radius: 18px;
+            background: rgba(99, 102, 241, 0.12);
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 1.8rem;
-            color: #5a67d8;
+            font-size: 2rem;
+            color: #4f46e5;
         }
 
         .festival-card h3 {
-            font-size: 1.6rem;
+            font-size: 1.45rem;
             margin: 0;
             color: #1f2937;
         }
 
         .festival-tagline {
-            color: #6366f1;
+            color: #4f46e5;
             margin: 0;
-            font-weight: 500;
+            font-weight: 600;
         }
 
         .festival-description {
             color: #4b5563;
-            line-height: 1.7;
+            line-height: 1.6;
             margin: 0;
-            position: relative;
-            z-index: 1;
+            font-size: 0.95rem;
         }
 
         .festival-countdown {
+            width: 100%;
             display: grid;
-            grid-template-columns: repeat(4, minmax(0, 1fr));
-            gap: 16px;
-            position: relative;
-            z-index: 1;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 12px;
         }
 
         .countdown-block {
-            background: rgba(99, 102, 241, 0.12);
+            background: rgba(99, 102, 241, 0.08);
             border-radius: 16px;
-            padding: 16px 12px;
-            text-align: center;
+            padding: 14px 10px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
         }
 
         .countdown-value {
-            font-size: 2.2rem;
+            font-size: 2rem;
             font-weight: 700;
             color: #4338ca;
             display: block;
         }
 
         .countdown-label {
-            font-size: 0.95rem;
-            color: #4b5563;
-            letter-spacing: 0.05em;
+            font-size: 0.85rem;
+            color: #4338ca;
+            letter-spacing: 0.08em;
         }
 
         .festival-next-date {
-            background: rgba(248, 250, 252, 0.95);
-            border-left: 4px solid #6366f1;
-            border-radius: 12px;
-            padding: 16px;
-            color: #1f2937;
-            font-weight: 500;
-            position: relative;
-            z-index: 1;
+            width: 100%;
+            background: rgba(79, 70, 229, 0.08);
+            border-radius: 14px;
+            padding: 14px 16px;
+            color: #312e81;
+            font-weight: 600;
         }
 
         .festival-next-date span {
             color: #4338ca;
         }
 
+        .festival-upcoming {
+            width: 100%;
+        }
+
         .festival-upcoming h4 {
-            font-size: 1.1rem;
-            color: #334155;
+            font-size: 1rem;
+            color: #3730a3;
             margin-bottom: 10px;
         }
 
@@ -302,15 +306,17 @@
             margin: 0;
             display: flex;
             flex-direction: column;
-            gap: 8px;
+            gap: 6px;
         }
 
         .festival-upcoming-list li {
             display: flex;
             align-items: center;
             gap: 8px;
-            color: #475569;
-            font-size: 0.95rem;
+            color: #4338ca;
+            font-size: 0.9rem;
+            justify-content: center;
+            text-align: left;
         }
 
         .festival-upcoming-list li i {
@@ -476,11 +482,23 @@
             transform: translateY(-2px);
         }
 
-        @media (max-width: 1024px) {
-            .festival-countdown {
+        @media (min-width: 640px) {
+            .festival-grid {
                 grid-template-columns: repeat(2, minmax(0, 1fr));
             }
 
+            .festival-countdown {
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+            }
+        }
+
+        @media (min-width: 960px) {
+            .festival-grid {
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+            }
+        }
+
+        @media (max-width: 1024px) {
             .festival-category-section {
                 padding: 24px;
             }
@@ -493,10 +511,6 @@
 
             .festival-hero h1 {
                 font-size: 2.2rem;
-            }
-
-            .festival-countdown {
-                grid-template-columns: repeat(2, minmax(0, 1fr));
             }
 
             .festival-category-nav {
@@ -522,10 +536,6 @@
         }
 
         @media (max-width: 520px) {
-            .festival-countdown {
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-            }
-
             .festival-category-link {
                 flex: 1 1 100%;
             }


### PR DESCRIPTION
## Summary
- restyled the festival countdown cards into a three-column nine-grid layout with centered content and hover feedback
- refreshed typography and countdown blocks for a cleaner visual hierarchy across breakpoints

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68dbdb9ae8908321931d60388a870b86