### PR TITLE
Add sitemap entries for ISEEtimer pages

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://yourdomain.com/sitemap.xml
+Sitemap: https://iseetimer.com/sitemap.xml
 
 # Disallow private directories (if any)
 Disallow: /private/

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,93 +3,117 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
         http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-    
-    <!-- 主页 - 倒计时器主页面 -->
+
+    <!-- 首页 -->
     <url>
-        <loc>https://yourdomain.com/</loc>
-        <lastmod>2024-01-01</lastmod>
+        <loc>https://iseetimer.com/</loc>
+        <lastmod>2024-05-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
-    <!-- 世界时间工具页面 -->
+    <!-- 世界时间工具 -->
     <url>
-        <loc>https://yourdomain.com/world-time-tools.html</loc>
-        <lastmod>2024-01-01</lastmod>
+        <loc>https://iseetimer.com/world-time-tools.html</loc>
+        <lastmod>2024-05-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
 
-    <!-- 重大节日倒计时页面 -->
+    <!-- 重大节日倒计时 -->
     <url>
-        <loc>https://yourdomain.com/festival-countdown.html</loc>
-        <lastmod>2024-01-01</lastmod>
+        <loc>https://iseetimer.com/festival-countdown.html</loc>
+        <lastmod>2024-05-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
 
-    <!-- 一炷香专注计时器页面 -->
+    <!-- 一炷香专注计时器 -->
     <url>
-        <loc>https://yourdomain.com/incense-timer.html</loc>
-        <lastmod>2024-01-01</lastmod>
+        <loc>https://iseetimer.com/incense-timer.html</loc>
+        <lastmod>2024-05-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.85</priority>
     </url>
 
-    <!-- 倒计时挑战小游戏页面 -->
+    <!-- 倒计时小游戏 -->
     <url>
-        <loc>https://yourdomain.com/countdown-game.html</loc>
-        <lastmod>2024-01-01</lastmod>
+        <loc>https://iseetimer.com/countdown-game.html</loc>
+        <lastmod>2024-05-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
 
-    <!-- 小游戏页面 -->
+    <!-- 经典计时小游戏合集 -->
     <url>
-        <loc>https://yourdomain.com/game.html</loc>
-        <lastmod>2024-01-01</lastmod>
+        <loc>https://iseetimer.com/game.html</loc>
+        <lastmod>2024-05-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
-    
-    <!-- 网站地图页面 -->
+
+    <!-- 婚礼倒计时 -->
     <url>
-        <loc>https://yourdomain.com/sitemap.html</loc>
-        <lastmod>2024-01-01</lastmod>
+        <loc>https://iseetimer.com/wedding-countdown.html</loc>
+        <lastmod>2024-05-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+
+    <!-- 考试倒计时 -->
+    <url>
+        <loc>https://iseetimer.com/exam-countdown.html</loc>
+        <lastmod>2024-05-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+
+    <!-- 生日倒计时 -->
+    <url>
+        <loc>https://iseetimer.com/birthday-countdown.html</loc>
+        <lastmod>2024-05-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+
+    <!-- 文章聚合页 -->
+    <url>
+        <loc>https://iseetimer.com/articles.html</loc>
+        <lastmod>2024-05-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.7</priority>
+    </url>
+
+    <!-- 网站建设时间规划 -->
+    <url>
+        <loc>https://iseetimer.com/article-time-planning.html</loc>
+        <lastmod>2024-05-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.6</priority>
     </url>
-    
-    <!-- 婚礼倒计时页面 -->
+
+    <!-- 网站建设方案规划 -->
     <url>
-        <loc>https://yourdomain.com/wedding-countdown.html</loc>
-        <lastmod>2024-01-01</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.9</priority>
+        <loc>https://iseetimer.com/article-website-planning.html</loc>
+        <lastmod>2024-05-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
     </url>
-    
-    <!-- 考试倒计时页面 -->
+
+    <!-- 制作教程 -->
     <url>
-        <loc>https://yourdomain.com/exam-countdown.html</loc>
-        <lastmod>2024-01-01</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.9</priority>
-    </url>
-    
-    <!-- 生日倒计时页面 -->
-    <url>
-        <loc>https://yourdomain.com/birthday-countdown.html</loc>
-        <lastmod>2024-01-01</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.9</priority>
-    </url>
-    
-    <!-- 制作教程页面 -->
-    <url>
-        <loc>https://yourdomain.com/how-to-create-countdown-timer.html</loc>
-        <lastmod>2024-01-01</lastmod>
+        <loc>https://iseetimer.com/how-to-create-countdown-timer.html</loc>
+        <lastmod>2024-05-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
-    
+
+    <!-- 网站地图 -->
+    <url>
+        <loc>https://iseetimer.com/sitemap.html</loc>
+        <lastmod>2024-05-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
 </urlset>


### PR DESCRIPTION
## Summary
- expand `sitemap.xml` with canonical `https://iseetimer.com` URLs for every public page to aid indexing
- update `robots.txt` to reference the new sitemap location for crawlers

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68dcf8f95c948321bd128b64f2a54864