### PR TITLE
Add AI tools navigator landing page

### DIFF
--- a/free-ai-tools.html
+++ b/free-ai-tools.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Free AI Tools Online | AI Tools Navigator</title>
+    <meta name="description" content="Explore curated free AI tools online with AI Tools Navigator. Compare image, video, voice, and chatbot solutions and discover student and business AI stacks without login barriers.">
+    <meta name="keywords" content="free ai tools, ai image generator, ai video maker, ai text to speech, ai chatbot, ai tools navigator">
+    <meta name="author" content="AI Tools Navigator">
+    <meta name="robots" content="index, follow">
+
+    <link rel="canonical" href="https://yourdomain.com/free-ai-tools.html">
+
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://yourdomain.com/free-ai-tools.html">
+    <meta property="og:title" content="Free AI Tools Online | AI Tools Navigator">
+    <meta property="og:description" content="Browse AI image, video, voice, and chatbot platforms with our curated catalog of free AI tools.">
+    <meta property="og:image" content="https://yourdomain.com/og-ai-tools.jpg">
+
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://yourdomain.com/free-ai-tools.html">
+    <meta property="twitter:title" content="Free AI Tools Online | AI Tools Navigator">
+    <meta property="twitter:description" content="Discover the best free AI tools online for creative, marketing, voice, and support teams.">
+    <meta property="twitter:image" content="https://yourdomain.com/og-ai-tools.jpg">
+
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="preload" href="styles.css" as="style">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" as="style">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+</head>
+<body class="ai-tools-body">
+    <header class="ai-header" role="banner">
+        <div class="ai-header-inner">
+            <div class="ai-brand">
+                <i class="fas fa-compass"></i>
+                <div>
+                    <span class="ai-brand-label">AI Tools Navigator</span>
+                    <p>Curated directories of free AI software for every workflow</p>
+                </div>
+            </div>
+            <div class="ai-header-links" role="navigation" aria-label="AI tools quick links">
+                <a href="#creative" class="ai-link">Creative</a>
+                <a href="#marketing" class="ai-link">Marketing</a>
+                <a href="#voice" class="ai-link">Voice</a>
+                <a href="#support" class="ai-link">Support</a>
+            </div>
+        </div>
+    </header>
+
+    <main class="ai-tools-main" role="main">
+        <div class="ai-tools-wrapper">
+            <section class="ai-hero" aria-labelledby="ai-hero-title">
+                <div class="ai-hero-content">
+                    <div class="ai-hero-badge">Free AI Tools Online</div>
+                    <h1 id="ai-hero-title">Explore curated platforms without paywalls or login walls</h1>
+                    <p>Discover open source AI tools and no-signup platforms for rapid experiments. Our navigator highlights free image generators, browser-based video makers, multilingual text-to-speech studios, and chatbot builders that integrate with your API stack.</p>
+                    <div class="ai-hero-highlights" aria-label="Key categories">
+                        <span><i class="fas fa-image"></i> Image</span>
+                        <span><i class="fas fa-video"></i> Video</span>
+                        <span><i class="fas fa-volume-up"></i> Voice</span>
+                        <span><i class="fas fa-robot"></i> Chatbot</span>
+                    </div>
+                </div>
+                <div class="ai-hero-illustration" aria-hidden="true">
+                    <div class="ai-orb orb-one"></div>
+                    <div class="ai-orb orb-two"></div>
+                    <div class="ai-orb orb-three"></div>
+                </div>
+            </section>
+
+            <section class="ai-category-grid" aria-label="AI categories">
+                <article id="creative" class="ai-category-card">
+                    <div class="ai-category-label">Creative</div>
+                    <h2>AI Image Generator Tools</h2>
+                    <p>Generate artwork, marketing mockups, and branded visuals with free AI studios and open source diffusion models you can self-host or run in the browser.</p>
+                </article>
+                <article id="marketing" class="ai-category-card">
+                    <div class="ai-category-label">Marketing</div>
+                    <h2>AI Video Generator Online</h2>
+                    <p>Create promos, tutorials, and vertical clips in minutes with browser-based AI video makers, automated editors, and text-to-motion templates.</p>
+                </article>
+                <article id="voice" class="ai-category-card">
+                    <div class="ai-category-label">Voice</div>
+                    <h2>AI Text to Speech Tools</h2>
+                    <p>Convert scripts into realistic narration, podcasts, and tutorials using multilingual synthetic voices, batch rendering, and SSML controls.</p>
+                </article>
+                <article id="support" class="ai-category-card">
+                    <div class="ai-category-label">Support</div>
+                    <h2>AI Chatbot Platform</h2>
+                    <p>Deploy conversational assistants that blend chat automation with machine learning, rapid API integration, and knowledge base syncing.</p>
+                </article>
+            </section>
+
+            <section class="ai-compare" aria-labelledby="ai-compare-title">
+                <div class="ai-compare-content">
+                    <h2 id="ai-compare-title">Compare the Best AI Tools</h2>
+                    <p>Use our AI Tools Navigator to benchmark 2025-ready solutions across every product category. Track machine learning research stacks, evaluate productivity automation, and follow emerging AI startups before they reach the mainstream.</p>
+                    <ul class="ai-compare-list">
+                        <li>Monitor roadmap velocity and community adoption metrics.</li>
+                        <li>Filter by pricing model, deployment options, and integration depth.</li>
+                        <li>Export curated shortlists for stakeholder reviews and pilots.</li>
+                    </ul>
+                </div>
+            </section>
+
+            <section class="ai-resource-grid" aria-labelledby="ai-resource-title">
+                <h2 id="ai-resource-title">Additional Navigator Guides</h2>
+                <div class="ai-resource-cards">
+                    <article class="ai-resource-card">
+                        <h3>Compare AI Tools 2025 Guide</h3>
+                        <p>Survey category leaders, pricing shifts, and deployment strategies shaping the next generation of AI products.</p>
+                    </article>
+                    <article class="ai-resource-card">
+                        <h3>Artificial Intelligence Platform Reviews</h3>
+                        <p>Read in-depth assessments of enterprise platforms spanning governance, customization, and model extensibility.</p>
+                    </article>
+                    <article class="ai-resource-card">
+                        <h3>Machine Learning Tools Catalog</h3>
+                        <p>Index research-ready notebooks, AutoML pipelines, vector databases, and experiment tracking utilities.</p>
+                    </article>
+                    <article class="ai-resource-card">
+                        <h3>Trending AI Startups Radar</h3>
+                        <p>Follow emerging founders, funding rounds, and breakout product launches before they go mainstream.</p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="ai-segments" aria-labelledby="ai-segments-title">
+                <h2 id="ai-segments-title">AI Tools Playbooks</h2>
+                <div class="ai-segment-grid">
+                    <article class="ai-segment-card" aria-labelledby="ai-students-title">
+                        <h3 id="ai-students-title">AI Tools for Students</h3>
+                        <p>Empower learners with course-ready copilots, collaborative note capture, and creative studios that emphasize free access without login barriers.</p>
+                        <ul>
+                            <li>Collaborative writing suites, flashcard generators, and accessible text-to-speech.</li>
+                            <li>Open source copilots that assist with coding practice and research summaries.</li>
+                            <li>Rapid prototyping canvases for presentations and visual project ideas.</li>
+                        </ul>
+                    </article>
+                    <article class="ai-segment-card" aria-labelledby="ai-business-title">
+                        <h3 id="ai-business-title">AI Tools for Business</h3>
+                        <p>Streamline customer journeys with chatbot platforms, marketing copilots, and dashboards that connect to your data through lightweight API integration.</p>
+                        <ul>
+                            <li>Automation workflows tailored to sales enablement, support, and content ops.</li>
+                            <li>Realtime analytics surfaces insights on trending AI startups and competitors.</li>
+                            <li>Composable stacks that plug into CRM, helpdesk, and knowledge hubs.</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <script src="footer.js" defer></script>
+</body>
+</html>

--- a/sitemap.html
+++ b/sitemap.html
@@ -197,6 +197,15 @@
                                 刺激有趣的在线倒计时小游戏，挑战您的反应速度和持久力
                             </div>
                         </li>
+                        <li>
+                            <a href="free-ai-tools.html">
+                                <i class="fas fa-robot"></i>
+                                免费AI工具导航
+                            </a>
+                            <div class="sitemap-description">
+                                浏览无需登录的AI图像、视频、语音与聊天机器人平台合集。
+                            </div>
+                        </li>
                     </ul>
                 </section>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -60,6 +60,14 @@
         <priority>0.8</priority>
     </url>
 
+    <!-- 免费AI工具导航 -->
+    <url>
+        <loc>https://www.iseetime.online/free-ai-tools.html</loc>
+        <lastmod>2024-05-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.75</priority>
+    </url>
+
     <!-- 婚礼倒计时 -->
     <url>
         <loc>https://www.iseetime.online/wedding-countdown.html</loc>

--- a/styles.css
+++ b/styles.css
@@ -1851,3 +1851,476 @@ body {
         justify-content: center;
     }
 }
+
+/* AI Tools Navigator Page */
+.ai-tools-body {
+    background: linear-gradient(180deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
+    color: var(--text-primary);
+    min-height: 100vh;
+}
+
+.ai-header {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: var(--shadow-sm);
+}
+
+[data-theme="dark"] .ai-header {
+    background: rgba(15, 23, 42, 0.9);
+}
+
+.ai-header-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+}
+
+.ai-brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: var(--accent-color);
+}
+
+.ai-brand i {
+    font-size: 2rem;
+    background: linear-gradient(135deg, var(--accent-color), #8b5cf6);
+    color: #ffffff;
+    padding: 0.75rem;
+    border-radius: 1rem;
+    box-shadow: var(--shadow-md);
+}
+
+.ai-brand-label {
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    display: block;
+    color: var(--text-primary);
+}
+
+.ai-brand p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.ai-header-links {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.ai-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: all 0.25s ease;
+}
+
+.ai-link:hover {
+    color: #ffffff;
+    background: var(--accent-color);
+    border-color: var(--accent-color);
+    box-shadow: var(--shadow-sm);
+}
+
+.ai-tools-main {
+    padding: 0 1rem 4rem;
+}
+
+.ai-tools-wrapper {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 3.5rem;
+}
+
+.ai-hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 3rem;
+    align-items: center;
+    padding: 3.5rem 3rem;
+    border-radius: 32px;
+    background: linear-gradient(135deg, #312e81 0%, #3b82f6 40%, #22d3ee 100%);
+    position: relative;
+    overflow: hidden;
+    color: #ffffff;
+    box-shadow: 0 35px 80px rgba(59, 130, 246, 0.35);
+}
+
+.ai-hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.28), transparent 55%);
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.ai-hero-content {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.ai-hero-badge {
+    width: fit-content;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.18);
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.ai-hero h1 {
+    font-size: clamp(2.2rem, 4vw, 3.2rem);
+    line-height: 1.15;
+    font-weight: 700;
+}
+
+.ai-hero p {
+    font-size: 1.05rem;
+    line-height: 1.8;
+    max-width: 620px;
+    opacity: 0.95;
+}
+
+.ai-hero-highlights {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.ai-hero-highlights span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.25);
+    font-size: 0.9rem;
+    letter-spacing: 0.03em;
+}
+
+.ai-hero-illustration {
+    position: relative;
+    min-height: 280px;
+    z-index: 1;
+}
+
+.ai-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(0px);
+    opacity: 0.8;
+}
+
+.ai-orb.orb-one {
+    width: 220px;
+    height: 220px;
+    top: 20px;
+    right: 30px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.75), rgba(59, 130, 246, 0.65));
+}
+
+.ai-orb.orb-two {
+    width: 160px;
+    height: 160px;
+    bottom: 40px;
+    right: 120px;
+    background: radial-gradient(circle, rgba(14, 165, 233, 0.65), rgba(59, 130, 246, 0.4));
+}
+
+.ai-orb.orb-three {
+    width: 120px;
+    height: 120px;
+    bottom: 10px;
+    right: 10px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.55), rgba(59, 130, 246, 0.3));
+}
+
+.ai-category-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.75rem;
+}
+
+.ai-category-card {
+    position: relative;
+    background: var(--bg-primary);
+    border-radius: 1.5rem;
+    padding: 2.25rem 2rem;
+    border: 1px solid rgba(59, 130, 246, 0.1);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ai-category-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(14, 165, 233, 0.08));
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.ai-category-card:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--shadow-lg);
+}
+
+.ai-category-card:hover::after {
+    opacity: 1;
+}
+
+.ai-category-label {
+    width: fit-content;
+    padding: 0.45rem 0.95rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.12);
+    color: var(--accent-color);
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+}
+
+.ai-category-card h2 {
+    font-size: 1.45rem;
+    margin-bottom: 0.75rem;
+    color: var(--text-primary);
+}
+
+.ai-category-card p {
+    color: var(--text-secondary);
+    line-height: 1.8;
+    margin: 0;
+}
+
+.ai-compare {
+    background: linear-gradient(135deg, var(--bg-primary) 0%, rgba(59, 130, 246, 0.12) 100%);
+    border-radius: 1.75rem;
+    padding: 3rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: var(--shadow-md);
+}
+
+.ai-compare h2 {
+    font-size: 1.9rem;
+    margin-bottom: 1rem;
+}
+
+.ai-compare p {
+    color: var(--text-secondary);
+    margin-bottom: 1.5rem;
+    max-width: 680px;
+}
+
+.ai-compare-list {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.ai-compare-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    color: var(--text-primary);
+    font-weight: 500;
+    position: relative;
+    padding-left: 1.75rem;
+}
+
+.ai-compare-list li::before {
+    content: "\f00c";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    position: absolute;
+    left: 0;
+    top: 0.15rem;
+    color: var(--accent-color);
+}
+
+.ai-segments {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.ai-segments > h2 {
+    font-size: 1.9rem;
+}
+
+.ai-segment-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.75rem;
+}
+
+.ai-segment-card {
+    background: var(--bg-primary);
+    border-radius: 1.5rem;
+    padding: 2.5rem 2rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: var(--shadow-md);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.ai-segment-card h3 {
+    font-size: 1.5rem;
+}
+
+.ai-segment-card p {
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.ai-segment-card ul {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.ai-segment-card li {
+    position: relative;
+    padding-left: 1.5rem;
+    color: var(--text-primary);
+}
+
+.ai-segment-card li::before {
+    content: "\2022";
+    position: absolute;
+    left: 0;
+    top: -0.1rem;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: var(--accent-color);
+}
+
+.ai-resource-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.ai-resource-grid > h2 {
+    font-size: 1.8rem;
+}
+
+.ai-resource-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.ai-resource-card {
+    background: var(--bg-primary);
+    border-radius: 1.35rem;
+    padding: 1.8rem 1.6rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ai-resource-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-md);
+}
+
+.ai-resource-card h3 {
+    font-size: 1.25rem;
+    margin-bottom: 0.75rem;
+    color: var(--text-primary);
+}
+
+.ai-resource-card p {
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.7;
+}
+
+@media (max-width: 1024px) {
+    .ai-header-inner {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .ai-header-links {
+        width: 100%;
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 768px) {
+    .ai-hero {
+        padding: 2.5rem 2rem;
+    }
+
+    .ai-tools-wrapper {
+        padding: 2rem 1rem 4rem;
+    }
+
+    .ai-compare {
+        padding: 2.25rem;
+    }
+}
+
+@media (max-width: 540px) {
+    .ai-header {
+        position: static;
+    }
+
+    .ai-header-inner {
+        padding: 1rem;
+    }
+
+    .ai-header-links {
+        justify-content: center;
+    }
+
+    .ai-hero {
+        padding: 2rem 1.5rem;
+    }
+
+    .ai-hero-highlights span {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .ai-category-card {
+        padding: 1.8rem 1.6rem;
+    }
+
+    .ai-segment-card {
+        padding: 2rem 1.6rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `free-ai-tools.html` landing page that curates free AI tool categories, comparison guidance, and student/business playbooks
- extend the global stylesheet with new AI Tools Navigator layouts and responsive styles
- register the new page in the HTML sitemap and XML sitemap for discoverability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df135528b48321bf7ad8f07184950c